### PR TITLE
Skip update for clients lower than 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - sudo apt-get install -y bsdiff
 
 install:
+  - curl https://glide.sh/get | sh
   - make vendor
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get install -y bsdiff
 
 install:
-  - go get -t -v -d ./...
+  - make vendor
 
 script:
   - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - make vendor
 
 script:
-  - go test -v ./...
+  - go test -v $(glide novendor)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_install:
   - sudo apt-get install -y bsdiff
 
 install:
+  - mkdir -p $GOPATH/bin
+  - mkdir -p $GOPATH/pkg
+  - mkdir -p $GOPATH/src
   - curl https://glide.sh/get | sh
   - make vendor
 

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,9 @@ import (
 	"github.com/getlantern/golog"
 )
 
+// Version 3.6.0
+var v360 = semver.MustParse("3.6.0")
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }
@@ -239,12 +242,11 @@ func (u *UpdateServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if params.OS == "darwin" {
-		v360, err := semver.Make("3.6.0")
+		currentVersion, err := semver.Parse(params.AppVersion)
 		if err != nil {
-			log.Debugf("semver.Make: %v", err)
+			log.Debugf("Failed to parse version (%q): %v", params.AppVersion, err)
 			u.closeWithStatus(w, http.StatusNoContent)
 		}
-		currentVersion, err := semver.Parse(params.AppVersion)
 		if currentVersion.LT(v360) {
 			log.Debugf("Got version %q on OSX, but we cannot update it. Skipped", params.AppVersion)
 			u.closeWithStatus(w, http.StatusNoContent)

--- a/server/server.go
+++ b/server/server.go
@@ -238,6 +238,19 @@ func (u *UpdateServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if params.OS == "darwin" {
+		v360, err := semver.Make("3.6.0")
+		if err != nil {
+			log.Debugf("semver.Make: %v", err)
+			u.closeWithStatus(w, http.StatusNoContent)
+		}
+		currentVersion, err := semver.Parse(params.AppVersion)
+		if currentVersion.LT(v360) {
+			log.Debugf("Got version %q on OSX, but we cannot update it. Skipped", params.AppVersion)
+			u.closeWithStatus(w, http.StatusNoContent)
+		}
+	}
+
 	log.Debugf("Got query from client %q/%q, resolved to upgrade to %q using %q strategy.", params.AppVersion, params.OS, res.Version, res.PatchType)
 
 	if res.PatchURL != "" {


### PR DESCRIPTION
This PR will ignore OSX clients < 3.6.0. The auto-update feature was failing for them on Sierra.