### PR TITLE
When receiving dev version from Android, assuming old version of Android

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -11,8 +11,9 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/getlantern/golog"
 	"golang.org/x/time/rate"
+
+	"github.com/getlantern/golog"
 )
 
 const (
@@ -136,6 +137,10 @@ func (g *ReleaseManager) CheckForUpdate(p *Params, isLantern bool) (res *Result,
 	appVersion, err := semver.Parse(p.AppVersion)
 	if err != nil {
 		return nil, fmt.Errorf("Bad app version string %v: %v", p.AppVersion, err)
+	}
+	if p.OS == OS.Android && p.AppVersion == "9999.99.99-dev" {
+		log.Debugf("received dev version string %v from android device, assume really low version", p.AppVersion)
+		appVersion, _ = semver.Parse("1.0.0")
 	}
 
 	var update *Asset


### PR DESCRIPTION
There is a widely deployed Android release in the wild that mistakenly thinks it's our dev version `9999.99.99-dev`. These clients will never auto-update.

This PR changes the update server so that if it sees this version from Android, it will treat it like a really old version of Lantern and auto-update it.